### PR TITLE
fix: set explicit iframe referrerPolicy on connect iframe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -322,7 +322,7 @@ export default class Solflare extends EventEmitter {
     this._element = document.createElement('div');
     this._element.className = 'solflare-wallet-adapter-iframe';
     this._element.innerHTML = `
-      <iframe src='${iframeUrl}' style='position: fixed; top: 0; bottom: 0; left: 0; right: 0; width: 100%; height: 100%; border: none; border-radius: 0; z-index: 99999; color-scheme: auto;' allowtransparency='true'></iframe>
+      <iframe src='${iframeUrl}' referrerPolicy='strict-origin-when-cross-origin' style='position: fixed; top: 0; bottom: 0; left: 0; right: 0; width: 100%; height: 100%; border: none; border-radius: 0; z-index: 99999; color-scheme: auto;' allowtransparency='true'></iframe>
     `;
     document.body.appendChild(this._element);
     this._iframe = this._element.querySelector('iframe');


### PR DESCRIPTION
This enables the wallet connect iframe to work even when the host site's referer-policy is `no-referer`. 