### PR TITLE
Transaction forwarding for web

### DIFF
--- a/src/adapters/WalletProvider.js
+++ b/src/adapters/WalletProvider.js
@@ -178,38 +178,6 @@ export default class Wallet extends EventEmitter {
       publicKey,
     };
   };
-
-  signTransaction = async (transaction) => {
-    const response = await this._sendRequest('signTransaction', {
-      message: bs58.encode(transaction.serializeMessage()),
-    });
-    const signature = bs58.decode(response.signature);
-    const publicKey = new PublicKey(response.publicKey);
-    transaction.addSignature(publicKey, signature);
-    return transaction;
-  };
-
-  signAllTransactions = async (transactions) => {
-    const response = await this._sendRequest('signAllTransactions', {
-      messages: transactions.map((tx) => bs58.encode(tx.serializeMessage())),
-    });
-    const signatures = response.signatures.map((s) => bs58.decode(s));
-    const publicKey = new PublicKey(response.publicKey);
-    transactions = transactions.map((tx, idx) => {
-      tx.addSignature(publicKey, signatures[idx]);
-      return tx;
-    });
-    return transactions;
-  };
-
-  signAndSendTransaction = async (transaction, options = {}) => {
-    const response = await this._sendRequest('signAndSendTransaction', {
-      transaction: bs58.encode(transaction.serialize({ requireAllSignatures: false, verifySignatures: false })),
-      ...options,
-    });
-    const { publicKey, signature } = response;
-    return { publicKey: new PublicKey(publicKey), signature };
-  };
 }
 
 function isString(a) {

--- a/src/adapters/iframe.ts
+++ b/src/adapters/iframe.ts
@@ -33,39 +33,39 @@ export default class IframeAdapter extends WalletAdapter {
     });
   }
 
-  async signTransaction (message: Uint8Array): Promise<Uint8Array> {
+  async signTransaction (transaction: Uint8Array): Promise<Uint8Array> {
     if (!this.connected) {
       throw new Error('Wallet not connected');
     }
 
     try {
-      const { signature } = await this._sendMessage({
+      const signedTransaction = await this._sendMessage({
         method: 'signTransaction',
         params: {
-          message: bs58.encode(message)
+          transaction: bs58.encode(transaction)
         }
-      }) as { publicKey: string, signature: string };
+      }) as string;
 
-      return bs58.decode(signature);
+      return bs58.decode(signedTransaction);
     } catch (e) {
       throw new Error(e?.toString?.() || 'Failed to sign transaction');
     }
   }
 
-  async signAllTransactions (messages: Uint8Array[]): Promise<Uint8Array[]> {
+  async signAllTransactions (transactions: Uint8Array[]): Promise<Uint8Array[]> {
     if (!this.connected) {
       throw new Error('Wallet not connected');
     }
 
     try {
-      const { signatures } = await this._sendMessage({
+      const signedTransactions = await this._sendMessage({
         method: 'signAllTransactions',
         params: {
-          messages: messages.map((message) => bs58.encode(message))
+          transactions: transactions.map((transaction) => bs58.encode(transaction))
         }
-      }) as { publicKey: string, signatures: string[] };
+      }) as string[];
 
-      return signatures.map((signature) => bs58.decode(signature));
+      return signedTransactions.map((transaction) => bs58.decode(transaction));
     } catch (e) {
       throw new Error(e?.toString?.() || 'Failed to sign transactions');
     }

--- a/src/adapters/web.ts
+++ b/src/adapters/web.ts
@@ -52,28 +52,28 @@ export default class WebAdapter extends WalletAdapter {
     await this._instance!.disconnect();
   }
 
-  async signTransaction (message: Uint8Array): Promise<Uint8Array> {
+  async signTransaction (transaction: Uint8Array): Promise<Uint8Array> {
     if (!this.connected) {
       throw new Error('Wallet not connected');
     }
 
-    const response = (await this._sendRequest('signTransaction', {
-      message: bs58.encode(message)
-    })) as { publicKey: string; signature: string };
+    const { transaction: signedTransaction } = (await this._sendRequest('signTransactionV2', {
+      transaction: bs58.encode(transaction)
+    })) as { transaction: string };
 
-    return bs58.decode(response.signature);
+    return bs58.decode(signedTransaction);
   }
 
-  async signAllTransactions (messages: Uint8Array[]): Promise<Uint8Array[]> {
+  async signAllTransactions (transactions: Uint8Array[]): Promise<Uint8Array[]> {
     if (!this.connected) {
       throw new Error('Wallet not connected');
     }
 
-    const response = (await this._sendRequest('signAllTransactions', {
-      messages: messages.map((message) => bs58.encode(message))
-    })) as { publicKey: string; signatures: string[] };
+    const { transactions: signedTransactions } = (await this._sendRequest('signAllTransactionsV2', {
+      transactions: transactions.map((transaction) => bs58.encode(transaction))
+    })) as { transactions: string[] };
 
-    return response.signatures.map((signature) => bs58.decode(signature));
+    return signedTransactions.map((transaction) => bs58.decode(transaction));
   }
 
   async signAndSendTransaction (transaction: Uint8Array, options?: SendOptions): Promise<string> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { TransactionOrVersionedTransaction } from './types';
-import { VersionedTransaction } from '@solana/web3.js';
+import { Transaction, VersionedTransaction } from '@solana/web3.js';
 
-export function isLegacyTransactionInstance (transaction: TransactionOrVersionedTransaction) {
+export function isLegacyTransactionInstance (transaction: TransactionOrVersionedTransaction): transaction is Transaction {
   return (transaction as VersionedTransaction).version === undefined;
 }


### PR DESCRIPTION

- Replace `message` with `transaction` and `messages` with `transactions`
- Remove old unused methods (signTransaction, signAllTransactions, and signAndSend) from WalletProvider