### PR TITLE
feat: implement signRawTransaction and signAllRawTransactions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,22 @@ export default class Solflare extends EventEmitter {
     this.emit('disconnect');
   }
 
+  async signRawTransaction (transaction: Uint8Array): Promise<Uint8Array> {
+    if (!this.connected) {
+      throw new Error('Wallet not connected');
+    }
+
+    return this._adapterInstance!.signTransaction(transaction);
+  }
+
+  async signAllRawTransactions (transactions: Uint8Array[]): Promise<Uint8Array[]> {
+    if (!this.connected) {
+      throw new Error('Wallet not connected');
+    }
+
+    return this._adapterInstance!.signAllTransactions(transactions);
+  }
+
   async signTransaction (transaction: TransactionOrVersionedTransaction): Promise<TransactionOrVersionedTransaction> {
     if (!this.connected) {
       throw new Error('Wallet not connected');


### PR DESCRIPTION
@solana/web3.js v2 does not provide Transaction/VersionedTransaction types. This PR adds support for signing raw transaction bytes to accomodate frontends/backends that do not build transactions using @solana/web3.js v1.